### PR TITLE
Shared ProjectのXamarin.Forms対応

### DIFF
--- a/Mastoom.Shared/Common/GuiThread.cs
+++ b/Mastoom.Shared/Common/GuiThread.cs
@@ -13,6 +13,11 @@ namespace Mastoom.Shared.Common
 			{
 				action();
 			});
+#else
+			Xamarin.Forms.Device.BeginInvokeOnMainThread(() => 
+			{
+                action();
+			});
 #endif
 		}
     }

--- a/Mastoom.Shared/Common/Timer.cs
+++ b/Mastoom.Shared/Common/Timer.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 namespace Mastoom.Shared.Common
 {
 	/// <summary>
-	/// Timer クラスが Xamarin.Forms で使えないので分岐するためのラッパー
+	/// System.Threading.Timer クラスが Xamarin.Forms で使えないので分岐するためのラッパー
 	/// </summary>
 	/// <remarks>
 	/// Xamarin.Forms側は Task.Delay 使ってみたけど、これはプラットフォーム非依存だから、
@@ -13,11 +13,11 @@ namespace Mastoom.Shared.Common
 	public class Timer
 	{
 #if WINDOWS_UWP
-        private readonly Timer _timer;
+        private readonly System.Threading.Timer _timer;
 
         public Timer(Action<object> callback, object state, int dueTime, int period)
         {
-            _timer = new Timer(s => callback?.Invoke(s), state, dueTime, period);
+            _timer = new System.Threading.Timer(s => callback?.Invoke(s), state, dueTime, period);
         }
 
         public bool Change(int dueTime, int period)

--- a/Mastoom.Shared/Common/Timer.cs
+++ b/Mastoom.Shared/Common/Timer.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace Mastoom.Shared.Common
+{
+	/// <summary>
+	/// Timer クラスが Xamarin.Forms で使えないので分岐するためのラッパー
+	/// </summary>
+	/// <remarks>
+	/// Xamarin.Forms側は Task.Delay 使ってみたけど、これはプラットフォーム非依存だから、
+	/// 問題がなければ UWP 側も Task.Delay で共通化してもよいかも。
+	/// </remarks>
+	public class Timer
+	{
+#if WINDOWS_UWP
+        private readonly Timer _timer;
+
+        public Timer(Action<object> callback, object state, int dueTime, int period)
+        {
+            _timer = new Timer(s => callback?.Invoke(s), state, dueTime, period);
+        }
+
+        public bool Change(int dueTime, int period)
+        {
+            return _timer.Change(dueTime, period);
+        }
+#else
+		private int _dueTime;
+		private int _period;
+		public Timer(Action<object> callback, object state, int dueTime, int period)
+		{
+			_dueTime = dueTime;
+			_period = period;
+            StartTimer(callback, state);
+		}
+
+		void StartTimer(Action<object> callback, object state)
+		{
+			if (_dueTime < 0 || _period < 0)
+			{
+				return;
+			}
+
+			Task.Run(async () => 
+			{
+				await Task.Delay(_dueTime);
+			   	while(true)
+				{
+					callback?.Invoke(this);
+					await Task.Delay(_period);
+    			}
+			});
+		}
+
+		public bool Change(int dueTime, int period)
+		{
+			// マイナス値には替えられないようにしちゃったけど大丈夫かな？
+			if (dueTime < 0 || period < 0)
+			{
+				return false;
+			}
+
+			_dueTime = dueTime; // 変えても意味ないけど
+			_period = period;
+			return true;
+		}
+#endif
+	}
+}

--- a/Mastoom.Shared/Converters/String2EmojiConverter.cs
+++ b/Mastoom.Shared/Converters/String2EmojiConverter.cs
@@ -3,7 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+#if WINDOWS_UWP
 using Windows.UI.Xaml.Data;
+#else
+using Xamarin.Forms;
+#endif
 
 namespace Mastoom.Shared.Converters
 {
@@ -11,11 +15,16 @@ namespace Mastoom.Shared.Converters
     {
 		private static readonly Dictionary<String, EmojiSharp.Emoji> dic = EmojiSharp.Emoji.All;
 
+#if WINDOWS_UWP
 		public object Convert(object value, Type targetType, object parameter, string language)
+#else
+		public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo info)
+#endif
 		{
-			if (value is string text && targetType == typeof(string))
+			string text = value as string;
+			if (text != null && targetType == typeof(string))
 			{
-				if (string.IsNullOrWhiteSpace(text) || !text.Contains(':'))
+				if (string.IsNullOrWhiteSpace(text) || !text.Contains(":"))
 				{
 					return text;
 				}
@@ -49,7 +58,11 @@ namespace Mastoom.Shared.Converters
 			throw new NotSupportedException();
 		}
 
+#if WINDOWS_UWP
 		public object ConvertBack(object value, Type targetType, object parameter, string language)
+#else
+		public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo info)
+#endif
 		{
 			throw new NotImplementedException();
 		}

--- a/Mastoom.Shared/Mastoom.Shared.projitems
+++ b/Mastoom.Shared/Mastoom.Shared.projitems
@@ -32,5 +32,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Models\Mastodon\Status\PostStatusModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewModels\MainViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewModels\ViewModelBase.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Common\Timer.cs" />
   </ItemGroup>
 </Project>

--- a/Mastoom.Shared/Mastoom.Shared.projitems
+++ b/Mastoom.Shared/Mastoom.Shared.projitems
@@ -32,6 +32,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Models\Mastodon\Status\PostStatusModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewModels\MainViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewModels\ViewModelBase.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Models\Mastodon\Status\MastodonTag.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Models\Mastodon\Status\MastodonAttachment.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\Timer.cs" />
   </ItemGroup>
 </Project>

--- a/Mastoom.Shared/Models/Mastodon/Account/MastodonAccount.cs
+++ b/Mastoom.Shared/Models/Mastodon/Account/MastodonAccount.cs
@@ -80,7 +80,7 @@ namespace Mastoom.Shared.Models.Mastodon.Account
             this.DisplayId = account.AccountName;
             this.InstanceUri = account.AccountName.Split('@').ElementAtOrDefault(1) ??
                                account.ProfileUrl.Split('/').ElementAt(2);
-            this.IsLocal = !account.AccountName.Contains('@');
+            this.IsLocal = !account.AccountName.Contains("@");
 			this.Name = account.DisplayName;
 			this.IconUri = account.AvatarUrl;
 		}

--- a/Mastoom.Shared/Models/Mastodon/Connection/Function/TimelineFunctionBase.cs
+++ b/Mastoom.Shared/Models/Mastodon/Connection/Function/TimelineFunctionBase.cs
@@ -20,7 +20,7 @@ namespace Mastoom.Shared.Models.Mastodon.Connection.Function
         private bool isStreaming;
 
         private const int StreamingTimeOut = 10;    // 一定時間ストリーミングの更新がない時に接続し直す（バグ？）
-        private Timer timer;
+        private Shared.Common.Timer timer;
 
         public event EventHandler<ObjectFunctionUpdateEventArgs<MastodonStatus>> Updated;
         public event EventHandler<ObjectFunctionEventArgs<MastodonStatus>> Deleted;
@@ -29,7 +29,7 @@ namespace Mastoom.Shared.Models.Mastodon.Connection.Function
         public TimelineFunctionBase()
         {
             // ストリーミングの更新がタイムアウトした時の処理
-            this.timer = new Timer(async (sender) =>
+            this.timer = new Shared.Common.Timer(async (sender) =>
             {
                 await this.StopAsync();
                 await this.StartAsync();

--- a/Mastoom.Shared/Models/Mastodon/Status/MastodonAttachment.cs
+++ b/Mastoom.Shared/Models/Mastodon/Status/MastodonAttachment.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Mastonet.Entities;
+
+namespace Mastoom.Shared
+{
+	public class MastodonAttachment
+	{
+		public int Id { get; }
+		public string PreviewUrl { get; }
+		public string RemoteUrl { get; }
+		public string TextUrl { get; }
+		public string Url { get; }
+		public string Type { get; }
+
+		public MastodonAttachment(Attachment attachment)
+		{
+			Id = attachment.Id;
+			PreviewUrl = attachment.PreviewUrl;
+			RemoteUrl = attachment.RemoteUrl;
+			TextUrl = attachment.TextUrl;
+			Url = attachment.Url;
+			Type = attachment.Type;
+		}
+
+	}
+}

--- a/Mastoom.Shared/Models/Mastodon/Status/MastodonStatus.cs
+++ b/Mastoom.Shared/Models/Mastodon/Status/MastodonStatus.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
+using System.Linq;
 
 namespace Mastoom.Shared.Models.Mastodon.Status
 {
@@ -95,6 +96,51 @@ namespace Mastoom.Shared.Models.Mastodon.Status
         }
         private bool _isBoosted;
 
+		/// <summary>
+		/// 添付メディア(画像など)群
+		/// </summary>
+		/// <value>The media attachments.</value>
+		public IEnumerable<MastodonAttachment> MediaAttachments
+		{
+			get { return _mediaAttachments; }
+			private set
+			{
+				_mediaAttachments = value;
+				this.OnPropertyChanged();
+			}
+		}
+		private IEnumerable<MastodonAttachment> _mediaAttachments;
+
+		/// <summary>
+		/// タグ群
+		/// </summary>
+		/// <value>The tags.</value>
+		public IEnumerable<MastodonTag> Tags
+		{
+			get { return _tags; }
+			private set
+			{
+				_tags = value;
+				this.OnPropertyChanged();
+			}
+		}
+		private IEnumerable<MastodonTag> _tags;
+
+		private DateTime _createdAt;
+		public DateTime CreatedAt
+		{
+			get { return _createdAt; }
+			private set
+			{
+				if (_createdAt == value)
+				{
+					return;
+				}
+				_createdAt = value;
+				this.OnPropertyChanged();
+			}
+		}
+
         #region メソッド
 
         public MastodonStatus(int id, MastodonAccount account)
@@ -121,6 +167,8 @@ namespace Mastoom.Shared.Models.Mastodon.Status
             this.IsFavorited = status.Favourited ?? false;
             this.IsBoosted = status.Reblogged ?? false;
 			this.Account = new MastodonAccount(status.Account);
+			this.MediaAttachments = status.MediaAttachments.Select(x => new MastodonAttachment(x));
+            this.Tags = status.Tags.Select(x => new MastodonTag(x));
 		}
 
 		public void CopyTo(MastodonStatus to)
@@ -132,6 +180,8 @@ namespace Mastoom.Shared.Models.Mastodon.Status
 			to.Content = this.Content;
             to.IsFavorited = this.IsFavorited;
             to.IsBoosted = this.IsBoosted;
+            to.MediaAttachments = this.MediaAttachments.Select(x => x); // なんとなくIEnumerableのガワだけ生成しなおし
+            to.Tags = this.Tags.Select(x => x); // なんとなくIEnumerableのガワだけ生成しなおし
 		}
 
         #endregion

--- a/Mastoom.Shared/Models/Mastodon/Status/MastodonTag.cs
+++ b/Mastoom.Shared/Models/Mastodon/Status/MastodonTag.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Mastonet.Entities;
+
+namespace Mastoom.Shared
+{
+	public class MastodonTag
+	{
+		public string Name { get; }
+		public string Url { get; }
+
+		public MastodonTag(Tag tag)
+		{
+			Name = tag.Name;
+			Url = tag.Url;
+		}
+	}
+}

--- a/Mastoom.Shared/ViewModels/ViewModelBase.cs
+++ b/Mastoom.Shared/ViewModels/ViewModelBase.cs
@@ -44,8 +44,9 @@ namespace Mastoom.Shared.ViewModels
 
 			public void Execute(object parameter)
 			{
-				if (parameter is T obj)
+				if (parameter is T)
 				{
+					var obj = (T)parameter;
 					this.action.Invoke(obj);
 				}
 			}


### PR DESCRIPTION
Xamarin.Forms で Android/iOS アプリを作るにあたり、 Mastoom.Shared を次のように直しました。

* Xamarin Studio stable で C# 7 がまだ使えないのでなくなく C# 6 にダウングレード
* Xamarin.Forms に対応してないクラス(``Timer`` や ``IValueConverter``) を ``#ifdef`` で Xamarin.Forms に対応させた
* ``MastodonStatus`` に MediaAttachments と Tags プロパティを追加（Parse で使いたいので）

とりあえずこれで一度 PR 送ります。
次の PR で Xamarin.Forms プロジェクト群を送ります。