### PR TITLE
OAuth AccessToken の保存と次回以降それを使用したログイン

### DIFF
--- a/Mastoom.Shared/Mastoom.Shared.projitems
+++ b/Mastoom.Shared/Mastoom.Shared.projitems
@@ -50,8 +50,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Models\Mastodon\Status\MastodonAttachment.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Common\Timer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\MastonetEntitiesExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Repositories\OAuthAccessTokenRepository.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)Extensions\" />
+    <Folder Include="$(MSBuildThisFileDirectory)Repositories\" />
   </ItemGroup>
 </Project>

--- a/Mastoom.Shared/Models/Mastodon/Connection/MastodonAuthenticationHouse.cs
+++ b/Mastoom.Shared/Models/Mastodon/Connection/MastodonAuthenticationHouse.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
+using Mastoom.Shared.Repositories;
 
 namespace Mastoom.Shared.Models.Mastodon.Connection
 {
@@ -17,6 +19,7 @@ namespace Mastoom.Shared.Models.Mastodon.Connection
         public static ReadOnlyObservableCollection<MastodonAuthentication> Authes { get; }
         private static readonly ObservableCollection<MastodonAuthentication> _authes = new ObservableCollection<MastodonAuthentication>();
 
+
         static MastodonAuthenticationHouse()
         {
             Authes = new ReadOnlyObservableCollection<MastodonAuthentication>(_authes);
@@ -29,7 +32,7 @@ namespace Mastoom.Shared.Models.Mastodon.Connection
         /// </summary>
         /// <param name="instanceUri">インスタンスURI</param>
         /// <returns>認証情報</returns>
-        public static MastodonAuthentication Get(string instanceUri)
+        public async static Task<MastodonAuthentication> Get(string instanceUri, OAuthAccessTokenRepository tokenRepo)
         {
             var auth = Authes.SingleOrDefault(a => a.InstanceUri == instanceUri);
             if (auth != null)
@@ -38,7 +41,8 @@ namespace Mastoom.Shared.Models.Mastodon.Connection
             }
             else
             {
-                var newAuth = new MastodonAuthentication(instanceUri);
+                var accessToken = await tokenRepo.Load(instanceUri);
+                var newAuth = new MastodonAuthentication(instanceUri, accessToken);
                 _authes.Add(newAuth);
                 return newAuth;
             }

--- a/Mastoom.Shared/Models/Mastodon/Connection/MastodonConnectionGroupCollection.cs
+++ b/Mastoom.Shared/Models/Mastodon/Connection/MastodonConnectionGroupCollection.cs
@@ -5,11 +5,13 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Text;
+using Mastoom.Shared.Repositories;
 
 namespace Mastoom.Shared.Models.Mastodon.Connection
 {
     public class MastodonConnectionGroupCollection : ObservableCollection<MastodonConnectionGroup>
     {
+        private readonly OAuthAccessTokenRepository tokenRepo = new OAuthAccessTokenRepository();
 #if DEBUG
         public void AddTestConnection()
         {
@@ -17,19 +19,19 @@ namespace Mastoom.Shared.Models.Mastodon.Connection
             {
                 Name = "Pawoo",
             });
-            this[0].TryAdd(new MastodonConnection("pawoo.net", new HomeTimelineFunctionContainer())
+            this[0].TryAdd(new MastodonConnection("pawoo.net", new HomeTimelineFunctionContainer(), tokenRepo)
             {
                 Name = "ホーム",
             });
-            this[0].TryAdd(new MastodonConnection("pawoo.net", new NotificationFunctionContainer())
+            this[0].TryAdd(new MastodonConnection("pawoo.net", new NotificationFunctionContainer(), tokenRepo)
             {
                 Name = "通知",
             });
-            this[0].TryAdd(new MastodonConnection("pawoo.net", new LocalTimelineFunctionContainer())
+            this[0].TryAdd(new MastodonConnection("pawoo.net", new LocalTimelineFunctionContainer(), tokenRepo)
             {
                 Name = "ローカルタイムライン",
             });
-            this[0].TryAdd(new MastodonConnection("pawoo.net", new PublicTimelineFunctionContainer())
+            this[0].TryAdd(new MastodonConnection("pawoo.net", new PublicTimelineFunctionContainer(), tokenRepo)
             {
                 Name = "公開タイムライン",
             });
@@ -38,19 +40,19 @@ namespace Mastoom.Shared.Models.Mastodon.Connection
             {
                 Name = "Mstdn",
             });
-            this[1].TryAdd(new MastodonConnection("mstdn.jp", new HomeTimelineFunctionContainer())
+            this[1].TryAdd(new MastodonConnection("mstdn.jp", new HomeTimelineFunctionContainer(), tokenRepo)
             {
                 Name = "ホーム",
             });
-            this[1].TryAdd(new MastodonConnection("mstdn.jp", new NotificationFunctionContainer())
+            this[1].TryAdd(new MastodonConnection("mstdn.jp", new NotificationFunctionContainer(), tokenRepo)
             {
                 Name = "通知",
             });
-            this[1].TryAdd(new MastodonConnection("mstdn.jp", new LocalTimelineFunctionContainer())
+            this[1].TryAdd(new MastodonConnection("mstdn.jp", new LocalTimelineFunctionContainer(), tokenRepo)
             {
                 Name = "ローカルタイムライン",
             });
-            this[1].TryAdd(new MastodonConnection("mstdn.jp", new PublicTimelineFunctionContainer())
+            this[1].TryAdd(new MastodonConnection("mstdn.jp", new PublicTimelineFunctionContainer(), tokenRepo)
             {
                 Name = "公開タイムライン",
             });

--- a/Mastoom.Shared/Repositories/OAuthAccessTokenRepository.cs
+++ b/Mastoom.Shared/Repositories/OAuthAccessTokenRepository.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Threading.Tasks;
+using Akavache;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+
+namespace Mastoom.Shared.Repositories
+{
+    /// <summary>
+    /// OAuth 認証済みの AccessToken を取得または保存するクラス
+    /// </summary>
+	public class OAuthAccessTokenRepository
+	{
+        /// <summary>
+        /// AccessToken を Instance URI と紐付けて保存する
+        /// </summary>
+        /// <returns>The save.</returns>
+        /// <param name="instanceUri">Instance URI.</param>
+        /// <param name="accessToken">Access token.</param>
+        public Task Save(string instanceUri, string accessToken)
+        {
+            return BlobCache.LocalMachine.InsertObject(instanceUri, accessToken).ToTask().ContinueWith(_ => 
+            {
+                BlobCache.LocalMachine.Flush();
+            });
+        }
+
+        /// <summary>
+        /// Instance URI に紐付いた AccessToken を読み出す。存在なかったら空文字。
+        /// </summary>
+        /// <returns>The load.</returns>
+        /// <param name="instanceUri">Instance URI.</param>
+        public Task<string> Load(string instanceUri)
+        {
+            return BlobCache.LocalMachine.GetOrCreateObject<string>(instanceUri, () => string.Empty).ToTask();
+        }
+    }
+}

--- a/Mastoom.UWP/project.json
+++ b/Mastoom.UWP/project.json
@@ -1,5 +1,6 @@
 ﻿{
   "dependencies": {
+    "akavache": "5.0.0",
     "HtmlAgilityPack": "1.4.9.5",
     "Microsoft.NETCore.UniversalWindowsPlatform": "5.2.2",
     "Microsoft.Xaml.Behaviors.Uwp.Managed": "2.0.0",

--- a/MastoomXF/MastoomXF.Droid/AkavacheSqliteLinkerOverride.cs
+++ b/MastoomXF/MastoomXF.Droid/AkavacheSqliteLinkerOverride.cs
@@ -1,0 +1,21 @@
+using System;
+using Akavache.Sqlite3;
+
+// Note: This class file is *required* for iOS to work correctly, and is 
+// also a good idea for Android if you enable "Link All Assemblies".
+namespace Mastoom.Droid
+{
+    [Preserve]
+    public static class LinkerPreserve
+    {
+        static LinkerPreserve()
+        {
+            throw new Exception(typeof(SQLitePersistentBlobCache).FullName);
+        }
+    }
+
+
+    public class PreserveAttribute : Attribute
+    {
+    }
+}

--- a/MastoomXF/MastoomXF.Droid/MastoomXF.Droid.csproj
+++ b/MastoomXF/MastoomXF.Droid/MastoomXF.Droid.csproj
@@ -119,6 +119,42 @@
     <Reference Include="CenterCLR.SgmlReader">
       <HintPath>..\packages\CenterCLR.SgmlReader.2016.3.27.2\lib\portable-net45+dnxcore+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10\CenterCLR.SgmlReader.dll</HintPath>
     </Reference>
+    <Reference Include="System.Reactive.Interfaces">
+      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Core">
+      <HintPath>..\packages\Rx-Core.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Linq">
+      <HintPath>..\packages\Rx-Linq.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices">
+      <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.PlatformServices.dll</HintPath>
+    </Reference>
+    <Reference Include="Splat">
+      <HintPath>..\packages\Splat.1.6.0\lib\monoandroid\Splat.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.core">
+      <HintPath>..\packages\SQLitePCLRaw.core.1.1.0\lib\MonoAndroid\SQLitePCLRaw.core.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.lib.e_sqlite3">
+      <HintPath>..\packages\SQLitePCLRaw.lib.e_sqlite3.android.1.1.0\lib\MonoAndroid\SQLitePCLRaw.lib.e_sqlite3.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.provider.e_sqlite3">
+      <HintPath>..\packages\SQLitePCLRaw.provider.e_sqlite3.android.1.1.0\lib\MonoAndroid\SQLitePCLRaw.provider.e_sqlite3.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.batteries_e_sqlite3">
+      <HintPath>..\packages\SQLitePCLRaw.bundle_e_sqlite3.1.1.0\lib\MonoAndroid\SQLitePCLRaw.batteries_e_sqlite3.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.batteries_v2">
+      <HintPath>..\packages\SQLitePCLRaw.bundle_e_sqlite3.1.1.0\lib\MonoAndroid\SQLitePCLRaw.batteries_v2.dll</HintPath>
+    </Reference>
+    <Reference Include="Akavache">
+      <HintPath>..\packages\akavache.core.5.0.0\lib\MonoAndroid\Akavache.dll</HintPath>
+    </Reference>
+    <Reference Include="Akavache.Sqlite3">
+      <HintPath>..\packages\akavache.sqlite3.5.0.0\lib\Portable-Net45+Win8+WP8+Wpa81\Akavache.Sqlite3.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MastoomXF\MastoomXF.csproj">
@@ -131,6 +167,7 @@
     <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Effects\ListViewScrollPlatformEffect.cs" />
+    <Compile Include="AkavacheSqliteLinkerOverride.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Resources\AboutResources.txt" />
@@ -150,7 +187,6 @@
   <ItemGroup>
     <Folder Include="Effects\" />
   </ItemGroup>
-  <Import Project="..\..\Mastoom.Shared\Mastoom.Shared.projitems" Label="Shared" Condition="Exists('..\..\Mastoom.Shared\Mastoom.Shared.projitems')" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <Import Project="..\packages\Xamarin.Android.Support.Vector.Drawable.24.2.1\build\Xamarin.Android.Support.Vector.Drawable.targets" Condition="Exists('..\packages\Xamarin.Android.Support.Vector.Drawable.24.2.1\build\Xamarin.Android.Support.Vector.Drawable.targets')" />
   <Import Project="..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.2.3.4.231\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+Xamarin.iOS10+xamarinmac20\Xamarin.Forms.targets')" />

--- a/MastoomXF/MastoomXF.Droid/Resources/Resource.designer.cs
+++ b/MastoomXF/MastoomXF.Droid/Resources/Resource.designer.cs
@@ -2072,6 +2072,7 @@ namespace Mastoom.Droid
 			global::CarouselView.FormsPlugin.Android.Resource.Styleable.ViewStubCompat_android_id = global::Mastoom.Droid.Resource.Styleable.ViewStubCompat_android_id;
 			global::CarouselView.FormsPlugin.Android.Resource.Styleable.ViewStubCompat_android_inflatedId = global::Mastoom.Droid.Resource.Styleable.ViewStubCompat_android_inflatedId;
 			global::CarouselView.FormsPlugin.Android.Resource.Styleable.ViewStubCompat_android_layout = global::Mastoom.Droid.Resource.Styleable.ViewStubCompat_android_layout;
+			global::Splat.Resource.String.library_name = global::Mastoom.Droid.Resource.String.library_name;
 		}
 		
 		public partial class Animation
@@ -5584,6 +5585,9 @@ namespace Mastoom.Droid
 			
 			// aapt resource value: 0x7f060016
 			public const int character_counter_pattern = 2131099670;
+			
+			// aapt resource value: 0x7f060038
+			public const int library_name = 2131099704;
 			
 			// aapt resource value: 0x7f060000
 			public const int mr_button_content_description = 2131099648;

--- a/MastoomXF/MastoomXF.Droid/packages.config
+++ b/MastoomXF/MastoomXF.Droid/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="akavache" version="5.0.0" targetFramework="monoandroid71" />
+  <package id="akavache.core" version="5.0.0" targetFramework="monoandroid71" />
+  <package id="akavache.sqlite3" version="5.0.0" targetFramework="monoandroid71" />
   <package id="CarouselView.FormsPlugin" version="4.1.2" targetFramework="monoandroid71" />
   <package id="CenterCLR.SgmlReader" version="2016.3.27.2" targetFramework="monoandroid71" />
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="monoandroid71" />
@@ -7,6 +10,16 @@
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="monoandroid71" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="monoandroid71" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="monoandroid71" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="monoandroid71" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="monoandroid71" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="monoandroid71" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="monoandroid71" />
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="monoandroid71" />
+  <package id="Splat" version="1.6.0" targetFramework="monoandroid71" />
+  <package id="SQLitePCLRaw.bundle_e_sqlite3" version="1.1.0" targetFramework="monoandroid71" />
+  <package id="SQLitePCLRaw.core" version="1.1.0" targetFramework="monoandroid71" />
+  <package id="SQLitePCLRaw.lib.e_sqlite3.android" version="1.1.0" targetFramework="monoandroid71" />
+  <package id="SQLitePCLRaw.provider.e_sqlite3.android" version="1.1.0" targetFramework="monoandroid71" />
   <package id="System.AppContext" version="4.3.0" targetFramework="monoandroid71" />
   <package id="System.Collections" version="4.3.0" targetFramework="monoandroid71" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="monoandroid71" />

--- a/MastoomXF/MastoomXF.iOS/AkavacheSqliteLinkerOverride.cs
+++ b/MastoomXF/MastoomXF.iOS/AkavacheSqliteLinkerOverride.cs
@@ -1,0 +1,21 @@
+using System;
+using Akavache.Sqlite3;
+
+// Note: This class file is *required* for iOS to work correctly, and is 
+// also a good idea for Android if you enable "Link All Assemblies".
+namespace Mastoom.iOS
+{
+    [Preserve]
+    public static class LinkerPreserve
+    {
+        static LinkerPreserve()
+        {
+            throw new Exception(typeof(SQLitePersistentBlobCache).FullName);
+        }
+    }
+
+
+    public class PreserveAttribute : Attribute
+    {
+    }
+}

--- a/MastoomXF/MastoomXF.iOS/MastoomXF.iOS.csproj
+++ b/MastoomXF/MastoomXF.iOS/MastoomXF.iOS.csproj
@@ -115,6 +115,42 @@
     <Reference Include="CenterCLR.SgmlReader">
       <HintPath>..\packages\CenterCLR.SgmlReader.2016.3.27.2\lib\portable-net45+dnxcore+win+wpa81+wp80+MonoAndroid10+xamarinios10+MonoTouch10\CenterCLR.SgmlReader.dll</HintPath>
     </Reference>
+    <Reference Include="System.Reactive.Interfaces">
+      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Core">
+      <HintPath>..\packages\Rx-Core.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Linq">
+      <HintPath>..\packages\Rx-Linq.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices">
+      <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\portable-windows8+net45+wp8\System.Reactive.PlatformServices.dll</HintPath>
+    </Reference>
+    <Reference Include="Splat">
+      <HintPath>..\packages\Splat.1.6.0\lib\Xamarin.iOS10\Splat.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.core">
+      <HintPath>..\packages\SQLitePCLRaw.core.1.1.0\lib\Xamarin.iOS10\SQLitePCLRaw.core.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.lib.e_sqlite3">
+      <HintPath>..\packages\SQLitePCLRaw.lib.e_sqlite3.ios_unified.static.1.1.0\lib\Xamarin.iOS10\SQLitePCLRaw.lib.e_sqlite3.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.provider.internal">
+      <HintPath>..\packages\SQLitePCLRaw.provider.internal.ios_unified.1.1.0\lib\Xamarin.iOS10\SQLitePCLRaw.provider.internal.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.batteries_e_sqlite3">
+      <HintPath>..\packages\SQLitePCLRaw.bundle_e_sqlite3.1.1.0\lib\Xamarin.iOS10\SQLitePCLRaw.batteries_e_sqlite3.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.batteries_v2">
+      <HintPath>..\packages\SQLitePCLRaw.bundle_e_sqlite3.1.1.0\lib\Xamarin.iOS10\SQLitePCLRaw.batteries_v2.dll</HintPath>
+    </Reference>
+    <Reference Include="Akavache">
+      <HintPath>..\packages\akavache.core.5.0.0\lib\Xamarin.iOS10\Akavache.dll</HintPath>
+    </Reference>
+    <Reference Include="Akavache.Sqlite3">
+      <HintPath>..\packages\akavache.sqlite3.5.0.0\lib\Portable-Net45+Win8+WP8+Wpa81\Akavache.Sqlite3.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MastoomXF\MastoomXF.csproj">
@@ -140,6 +176,7 @@
   <ItemGroup>
     <Compile Include="Main.cs" />
     <Compile Include="AppDelegate.cs" />
+    <Compile Include="AkavacheSqliteLinkerOverride.cs" />
   </ItemGroup>
   <Import Project="..\..\Mastoom.Shared\Mastoom.Shared.projitems" Label="Shared" Condition="Exists('..\..\Mastoom.Shared\Mastoom.Shared.projitems')" />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/MastoomXF/MastoomXF.iOS/packages.config
+++ b/MastoomXF/MastoomXF.iOS/packages.config
@@ -1,5 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="akavache" version="5.0.0" targetFramework="xamarinios10" />
+  <package id="akavache.core" version="5.0.0" targetFramework="xamarinios10" />
+  <package id="akavache.sqlite3" version="5.0.0" targetFramework="xamarinios10" />
   <package id="CarouselView.FormsPlugin" version="4.1.2" targetFramework="xamarinios10" />
   <package id="CenterCLR.SgmlReader" version="2016.3.27.2" targetFramework="xamarinios10" />
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="xamarinios10" />
@@ -7,6 +10,16 @@
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="xamarinios10" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="xamarinios10" />
   <package id="Newtonsoft.Json" version="10.0.2" targetFramework="xamarinios10" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="xamarinios10" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="xamarinios10" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="xamarinios10" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="xamarinios10" />
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="xamarinios10" />
+  <package id="Splat" version="1.6.0" targetFramework="xamarinios10" />
+  <package id="SQLitePCLRaw.bundle_e_sqlite3" version="1.1.0" targetFramework="xamarinios10" />
+  <package id="SQLitePCLRaw.core" version="1.1.0" targetFramework="xamarinios10" />
+  <package id="SQLitePCLRaw.lib.e_sqlite3.ios_unified.static" version="1.1.0" targetFramework="xamarinios10" />
+  <package id="SQLitePCLRaw.provider.internal.ios_unified" version="1.1.0" targetFramework="xamarinios10" />
   <package id="System.AppContext" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Collections" version="4.3.0" targetFramework="xamarinios10" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="xamarinios10" />

--- a/MastoomXF/MastoomXF/AkavacheSqliteLinkerOverride.cs
+++ b/MastoomXF/MastoomXF/AkavacheSqliteLinkerOverride.cs
@@ -1,0 +1,21 @@
+using System;
+using Akavache.Sqlite3;
+
+// Note: This class file is *required* for iOS to work correctly, and is 
+// also a good idea for Android if you enable "Link All Assemblies".
+namespace Mastoom
+{
+    [Preserve]
+    public static class LinkerPreserve
+    {
+        static LinkerPreserve()
+        {
+            throw new Exception(typeof(SQLitePersistentBlobCache).FullName);
+        }
+    }
+
+
+    public class PreserveAttribute : Attribute
+    {
+    }
+}

--- a/MastoomXF/MastoomXF/MastoomXF.csproj
+++ b/MastoomXF/MastoomXF/MastoomXF.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Converters\PlayConverter.cs" />
     <Compile Include="Behaviors\BindingContextPassingBehavior.cs" />
     <Compile Include="Converters\Time2ElapseConverter.cs" />
+    <Compile Include="AkavacheSqliteLinkerOverride.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Xamarin.Forms.Core">
@@ -100,6 +101,39 @@
     </Reference>
     <Reference Include="Mastonet">
       <HintPath>..\ext\Mastonet.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.3\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Interfaces">
+      <HintPath>..\packages\Rx-Interfaces.2.2.5\lib\portable-net45+winrt45+wp8+wpa81\System.Reactive.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Core">
+      <HintPath>..\packages\Rx-Core.2.2.5\lib\portable-net45+winrt45+wp8+wpa81\System.Reactive.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.Linq">
+      <HintPath>..\packages\Rx-Linq.2.2.5\lib\portable-net45+winrt45+wp8+wpa81\System.Reactive.Linq.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reactive.PlatformServices">
+      <HintPath>..\packages\Rx-PlatformServices.2.2.5\lib\portable-net45+winrt45+wp8+wpa81\System.Reactive.PlatformServices.dll</HintPath>
+    </Reference>
+    <Reference Include="Splat">
+      <HintPath>..\packages\Splat.1.6.0\lib\Portable-net45+win+wpa81+wp80\Splat.dll</HintPath>
+    </Reference>
+    <Reference Include="Akavache">
+      <HintPath>..\packages\akavache.core.5.0.0\lib\Portable-Net45+Win8+WP8+Wpa81\Akavache.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.core">
+      <HintPath>..\packages\SQLitePCLRaw.core.1.1.0\lib\portable-net45+netcore45+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\SQLitePCLRaw.core.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.batteries_e_sqlite3">
+      <HintPath>..\packages\SQLitePCLRaw.bundle_e_sqlite3.1.1.0\lib\portable-net45+netcore45+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\SQLitePCLRaw.batteries_e_sqlite3.dll</HintPath>
+    </Reference>
+    <Reference Include="SQLitePCLRaw.batteries_v2">
+      <HintPath>..\packages\SQLitePCLRaw.bundle_e_sqlite3.1.1.0\lib\portable-net45+netcore45+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\SQLitePCLRaw.batteries_v2.dll</HintPath>
+    </Reference>
+    <Reference Include="Akavache.Sqlite3">
+      <HintPath>..\packages\akavache.sqlite3.5.0.0\lib\Portable-Net45+Win8+WP8+Wpa81\Akavache.Sqlite3.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/MastoomXF/MastoomXF/Views/SingleTimelineView.xaml
+++ b/MastoomXF/MastoomXF/Views/SingleTimelineView.xaml
@@ -63,7 +63,8 @@
             <!--別画面にしたいな-->
             <WebView 
                 Grid.Row="1"
-                Grid.RowSpan="2" >
+                Grid.RowSpan="2" 
+				IsVisible="false">
                 <WebView.Behaviors>
                     <b:OAuthWebBehavior Helper="{Binding Activated.Auth.OAuthHelper}"/>
                 </WebView.Behaviors>

--- a/MastoomXF/MastoomXF/packages.config
+++ b/MastoomXF/MastoomXF/packages.config
@@ -1,6 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="akavache" version="5.0.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="akavache.core" version="5.0.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="akavache.sqlite3" version="5.0.0" targetFramework="portable45-net45+win8+wpa81" />
   <package id="CarouselView.FormsPlugin" version="4.1.2" targetFramework="portable45-net45+win8+wpa81" />
   <package id="CenterCLR.SgmlReader" version="2016.3.27.2" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="Rx-Core" version="2.2.5" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="Rx-Interfaces" version="2.2.5" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="Rx-Linq" version="2.2.5" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="Rx-PlatformServices" version="2.2.5" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="Splat" version="1.6.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="SQLitePCLRaw.bundle_e_sqlite3" version="1.1.0" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="SQLitePCLRaw.core" version="1.1.0" targetFramework="portable45-net45+win8+wpa81" />
   <package id="Xamarin.Forms" version="2.3.4.231" targetFramework="portable45-net45+win8+wpa81" />
 </packages>


### PR DESCRIPTION
#6

認証された AccessToken をローカルストレージに保存し、次回起動時はそれを使ってログインするようにしました。

保存には [Akavache](https://github.com/akavache/Akavache) を使っています(``Mastoom.Shared.Repositories.OAuthAccessTokenRepository`` でラップしています)。
簡単にローカルストレージにオブジェクトを保存・復元できるのでそれ使ってます。 Rx に依存してるけど、Rx をコード中で使うつもりはないです。

また、WebView による認証と、AccessToken による認証をリファクタして、
``MastodonAuthentication.DoAuth`` メソッドにまとめています。``TaskCompletionSource`` を使うとイベントを ``Task<T>`` に変換できるので便利です、ご参考まで〜。